### PR TITLE
Hotfix: gptz_response default value set to None instead of {}

### DIFF
--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -264,7 +264,7 @@ class StaffGradedAssignmentXBlock(StudioEditableXBlockMixin, ShowAnswerXBlockMix
             "filename": upload.file.name,
             "mimetype": mimetypes.guess_type(upload.file.name)[0],
             "finalized": False,
-            "gptz_response": {},
+            "gptz_response": None,
         }
         student_item_dict = self.get_student_item_dict()
         submissions_api.create_submission(student_item_dict, answer)
@@ -594,7 +594,7 @@ class StaffGradedAssignmentXBlock(StudioEditableXBlockMixin, ShowAnswerXBlockMix
                 status_code=400
             )
 
-        submission.answer['gptz_response'] = response.get('documents', [{}])[0]
+        submission.answer['gptz_response'] = response.get('documents', [None])[0]
         submission.save()
         return Response(json_body={'result': 'success'})
 
@@ -871,7 +871,7 @@ class StaffGradedAssignmentXBlock(StudioEditableXBlockMixin, ShowAnswerXBlockMix
                     'timestamp': submission['created_at'].strftime(
                         DateTime.DATETIME_FORMAT
                     ),
-                    'gptz_response': submission['answer'].get('gptz_response', {}),
+                    'gptz_response': submission['answer'].get('gptz_response', None),
                     'score': score,
                     'approved': approved,
                     'needs_approval': instructor and needs_approval,

--- a/edx_sga/static/css/edx_sga.css
+++ b/edx_sga/static/css/edx_sga.css
@@ -133,7 +133,7 @@
 #jv-modal {
     display: none;
     position: fixed;
-    z-index: 1;
+    z-index: 12;
     left: 0;
     top: 0;
     width: 100%;

--- a/edx_sga/static/js/src/edx_sga.js
+++ b/edx_sga/static/js/src/edx_sga.js
@@ -247,7 +247,7 @@ function StaffGradedAssignmentXBlock(runtime, element) {
                 setTimeout(function() {
                   $('#grade-submissions-button').click();
                   gradeFormError('');
-              }, 225);
+                }, 225);
               });
         }
 
@@ -257,7 +257,11 @@ function StaffGradedAssignmentXBlock(runtime, element) {
             var url = verifyUploadedFileUrl + '?student_id=' +
               row.data('student_id');
             $.get(url).success(function (res) {
-              console.log(res);
+              // Hide and open the modal for refreshed data
+              setTimeout(function() {
+                $('#grade-submissions-button').click();
+                gradeFormError('');
+              }, 225);
             });
         }
 


### PR DESCRIPTION
**Description**:

This PR hot fixes `gptz_response` default value set to None instead of {} as javascript consider {} to be true/valid

**JIRA**:
https://edlyio.atlassian.net/browse/EDLY-5457